### PR TITLE
Remove upper bound for pyramid dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(os.path.join(here, name, '__init__.py')) as v_file:
                          re.S).match(v_file.read()).group(1)
 
 
-requires = ['pyramid >1.3, <1.5.99',
+requires = ['pyramid >1.3',
             'htmlmin']
 
 


### PR DESCRIPTION
I would like to use this module. However, it is restricted to version released before 2016-01-03.